### PR TITLE
Accommodate single-ended and paired-end in the trimming_adapters workflow

### DIFF
--- a/conf/test_stub.config
+++ b/conf/test_stub.config
@@ -15,15 +15,15 @@ params {
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
     // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = '6.GB'
-    max_time   = '6.h'
+    max_cpus   = 1
+    max_memory = '1.GB'
+    max_time   = '1.h'
 
 }
 
 process {
 
-  beforeScript = 'sleep $(shuf -i 2-11 -n 1)'
+  beforeScript = 'sleep $(shuf -i 1-5 -n 1)'
 
 }
 

--- a/envs/BBMAP.yml
+++ b/envs/BBMAP.yml
@@ -1,7 +1,7 @@
 name: BBMAP
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - bbmap=38.96
+  - bbmap=38.96

--- a/envs/MMSEQS.yml
+++ b/envs/MMSEQS.yml
@@ -1,7 +1,7 @@
 name: MMSEQS
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - mmseqs2=13.45111
+  - mmseqs2=13.45111

--- a/envs/QC.yml
+++ b/envs/QC.yml
@@ -1,9 +1,9 @@
 name: QC
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - multiqc=1.12
- - fastqc=0.11.9
- - trimmomatic=0.39
+  - multiqc=1.12
+  - fastqc=0.11.9
+  - trimmomatic=0.39

--- a/envs/R.yml
+++ b/envs/R.yml
@@ -1,6 +1,6 @@
 name: R
 channels:
- - conda-forge
- - r
+  - conda-forge
+  - r
 dependencies:
- - r-base=4.1.3
+  - r-base=4.1.3

--- a/envs/checkv.yml
+++ b/envs/checkv.yml
@@ -1,8 +1,8 @@
 name: checkv
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - checkv=0.9.0
- - python=3.8
+  - checkv=0.9.0
+  - python=3.8

--- a/envs/minimap2.yml
+++ b/envs/minimap2.yml
@@ -1,9 +1,9 @@
 name: minimap2
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - minimap2=2.24
- - samtools=1.9
- - pigz=2.6
+  - minimap2=2.24
+  - samtools=1.9
+  - pigz=2.6

--- a/envs/seqkit.yml
+++ b/envs/seqkit.yml
@@ -1,7 +1,7 @@
 name: spades
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - seqkit=2.2.0
+  - seqkit=2.2.0

--- a/envs/spades.yml
+++ b/envs/spades.yml
@@ -1,8 +1,8 @@
 name: spades
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - python=3.7
- - spades=3.13.0
+  - python=3.7
+  - spades=3.13.0

--- a/envs/taxonkit.yml
+++ b/envs/taxonkit.yml
@@ -1,7 +1,7 @@
 name: taxonkit
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - taxonkit=0.12.0
+  - taxonkit=0.12.0

--- a/envs/virsorter2.yml
+++ b/envs/virsorter2.yml
@@ -1,7 +1,7 @@
 name: virsorter2
 channels:
- - bioconda
- - conda-forge
- - defaults
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
- - virsorter=2.2.3
+  - virsorter=2.2.3

--- a/envs/vrhyme.yml
+++ b/envs/vrhyme.yml
@@ -17,6 +17,6 @@ dependencies:
   - prodigal=2.6.3
   - samtools=1.6
   - pip:
-    - networkx==2.6.3
-    - pysam==0.19.1
-    - scikit-learn==1.0.2
+      - networkx==2.6.3
+      - pysam==0.19.1
+      - scikit-learn==1.0.2

--- a/main.nf
+++ b/main.nf
@@ -37,13 +37,6 @@ WorkflowMain.initialise(workflow, params, log)
 
 include { EVEREST } from './workflows/everest'
 
-//
-// WORKFLOW: Run main nf-core/everest analysis pipeline
-//
-workflow NFCORE_EVEREST {
-    EVEREST ()
-}
-
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     RUN ALL WORKFLOWS
@@ -55,7 +48,7 @@ workflow NFCORE_EVEREST {
 // See: https://github.com/nf-core/rnaseq/issues/619
 //
 workflow {
-    NFCORE_EVEREST ()
+    EVEREST ()
 }
 
 /*

--- a/modules/local/CAT_pair_unpair.nf
+++ b/modules/local/CAT_pair_unpair.nf
@@ -5,7 +5,7 @@ process CAT_PAIR_UNPAIR {
     //		conda (params.enable_conda ? 'bioconda::trimmomatic=0.39' : null)
 
         input:
-        tuple val(meta), path(p1), path(p2), path(up1), path(up2)
+        tuple val(meta), path(paired), path(unpaired)
         
         output:
         tuple val(meta), path('*_trimm_cat_R*.fastq.gz')	, emit: concatenated
@@ -16,8 +16,8 @@ process CAT_PAIR_UNPAIR {
         def args = task.ext.args ?: '-7'
         def prefix = task.ext.prefix ?: "${meta.id}"
         """
-        cat $p1 $up1 > ${prefix}_trimm_cat_R1.fastq.gz \\
-        cat $p2 $up2 > ${prefix}_trimm_cat_R2.fastq.gz \\
+        cat ${paired[0]} ${unpaired[0]} > ${prefix}_trimm_cat_R1.fastq.gz \\
+        cat ${paired[0]} ${unpaired[1]} > ${prefix}_trimm_cat_R2.fastq.gz \\
         > ${prefix}.CAT.pair_unpair.log
 
         cat <<-END_VERSIONS > versions.yml

--- a/modules/local/bbmap_phix.nf
+++ b/modules/local/bbmap_phix.nf
@@ -24,12 +24,16 @@ process BBMAP_PHIX {
         def args2 = task.ext.args ?: 'ordered=t cardinality=t k=31 hdist=1'
         def prefix = task.ext.prefix ?: "${meta.id}"
 
+        def input = meta.single_end ? "in=${reads[0]}" : "in1=${reads[0]} in2=${reads[1]}"
+        def output_clean = meta.single_end ? "out=${prefix}_clean_R1.fastq.gz" : "out1=${prefix}_clean_R1.fastq.gz out2=${prefix}_clean_R2.fastq.gz"
+        def output_noclean = meta.single_end ? "outm=${prefix}_noclean_R1.fastq.gz" : "outm1=${prefix}_noclean_R1.fastq.gz outm2=${prefix}_noclean_R2.fastq.gz"
+
         """
         bbduk.sh \\
           $args \\
-          in1=${reads[0]} in2=${reads[1]} \\
-          out1=${prefix}_clean_R1.fastq.gz out2=${prefix}_clean_R2.fastq.gz  \\
-          outm1=${prefix}_noclean_R1.fastq.gz outm2=${prefix}_noclean_R2.fastq.gz \\
+          ${input} \\
+          ${output_clean} \\
+          ${output_noclean} \\
           ref=artifacts,phix \\
           stats=${prefix}.stats_phix.txt \\
           $args2 \\
@@ -45,9 +49,15 @@ process BBMAP_PHIX {
         stub:
         def prefix = task.ext.prefix ?: "${meta.id}"
 
+        def input = meta.single_end ? "${reads[0]}" : "${reads[0]} ${reads[1]}"
+        def output_clean = meta.single_end ? "${prefix}_clean_R1.fastq.gz" : "${prefix}_clean_R1.fastq.gz ${prefix}_clean_R2.fastq.gz"
+        def output_noclean = meta.single_end ? "${prefix}_noclean_R1.fastq.gz" : "${prefix}_noclean_R1.fastq.gz ${prefix}_noclean_R2.fastq.gz"
+
+
         """
-        touch ${prefix}_clean_R1.fastq.gz ${prefix}_clean_R2.fastq.gz
-        touch ${prefix}_noclean_R1.fastq.gz ${prefix}_noclean_R2.fastq.gz
+        touch ${input}
+        touch ${output_clean}
+        touch ${output_noclean}
 
         touch ${prefix}.stats_phix.txt
         touch ${prefix}.bbmap_phix.log

--- a/modules/local/bbmap_phix.nf
+++ b/modules/local/bbmap_phix.nf
@@ -2,7 +2,7 @@ process BBMAP_PHIX {
         tag "$meta.id"
         label 'process_medium'
 
-        conda (params.enable_conda ? 'bioconda::bbmap=38.96' : null)
+        conda "envs/BBMAP.yml"
 
         container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
             'https://depot.galaxyproject.org/singularity/bbmap:38.96--h5c4e2a8_0':

--- a/modules/local/bbmap_reformat.nf
+++ b/modules/local/bbmap_reformat.nf
@@ -38,7 +38,7 @@ process BBMAP_REFORMAT {
         """
         touch ${prefix}_unmapped_singletons_R1.fastq 
         touch ${prefix}_unmapped_singletons_R2.fastq 
-        touch ${prefix}.BBMAP_singletons.log
+        touch ${prefix}.bbmap_singletons.log
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/local/bbmap_reformat.nf
+++ b/modules/local/bbmap_reformat.nf
@@ -13,7 +13,7 @@ process BBMAP_REFORMAT {
 
         output:
         tuple val(meta), path('*_unmapped_singletons_R*.fastq')	                , emit: singleton_pair
-        tuple val(meta), path('*BBMAP_singletons_PE.log')			                  , emit: log
+        tuple val(meta), path('*BBMAP_singletons.log')			                  , emit: log
         path "versions.yml"							                                        , emit: versions
 
         script:
@@ -25,7 +25,7 @@ process BBMAP_REFORMAT {
           $args \\
           in1=$unmapped_single \\
           out=${prefix}_unmapped_singletons_R1.fastq out2=${prefix}_unmapped_singletons_R2.fastq  \\
-          > ${prefix}.S3P3_BBMAP_singletons_PE.log
+          > ${prefix}.S3P3_BBMAP_singletons.log
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -38,7 +38,7 @@ process BBMAP_REFORMAT {
         """
         touch ${prefix}_unmapped_singletons_R1.fastq 
         touch ${prefix}_unmapped_singletons_R2.fastq 
-        touch ${prefix}.BBMAP_singletons_PE.log
+        touch ${prefix}.BBMAP_singletons.log
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/local/bbmap_reformat.nf
+++ b/modules/local/bbmap_reformat.nf
@@ -13,7 +13,7 @@ process BBMAP_REFORMAT {
 
         output:
         tuple val(meta), path('*_unmapped_singletons_R*.fastq')	                , emit: singleton_pair
-        tuple val(meta), path('*BBMAP_singletons.log')			                  , emit: log
+        tuple val(meta), path('*bbmap_singletons.log')			                    , emit: log
         path "versions.yml"							                                        , emit: versions
 
         script:
@@ -25,7 +25,7 @@ process BBMAP_REFORMAT {
           $args \\
           in1=$unmapped_single \\
           out=${prefix}_unmapped_singletons_R1.fastq out2=${prefix}_unmapped_singletons_R2.fastq  \\
-          > ${prefix}.S3P3_BBMAP_singletons.log
+          > ${prefix}.bbmap_singletons.log
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/modules/local/cat.nf
+++ b/modules/local/cat.nf
@@ -1,4 +1,4 @@
-process CAT_PE {
+process CAT {
         tag "$meta.id"
         label 'process_medium'
 
@@ -29,7 +29,7 @@ process CAT_PE {
 
             cat <<-END_VERSIONS > versions.yml
                 "${task.process}":
-                    CAT_PE: \$(cat --version)
+                    CAT: \$(cat --version)
                     pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
             END_VERSIONS
         """
@@ -43,7 +43,7 @@ process CAT_PE {
 
             cat <<-END_VERSIONS > versions.yml
                 "${task.process}":
-                    CAT_PE: \$(cat --version)
+                    CAT: \$(cat --version)
                     pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
             END_VERSIONS
 

--- a/modules/local/minimap2_host_removal.nf
+++ b/modules/local/minimap2_host_removal.nf
@@ -2,7 +2,7 @@ process MINIMAP2_HOST_REMOVAL {
         tag "$meta.id"
         label 'process_medium'
 
-        conda (params.enable_conda ? 'bioconda::minimap2=2.24 bioconda::samtools=1.9 bioconda::pigz=2.6' : null)
+        conda "envs/minimap2.yml"
 
 //        container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
 //            'https://depot.galaxyproject.org/singularity/bbmap:38.96--h5c4e2a8_0':

--- a/modules/local/trimm.nf
+++ b/modules/local/trimm.nf
@@ -1,4 +1,4 @@
-process TRIMM_PE {
+process TRIMM {
         tag "$meta.id"
         label 'process_medium'
 
@@ -27,11 +27,11 @@ process TRIMM_PE {
             ${clean[0]} ${clean[1]} \\
             ${prefix}_trimm_pair_R1.fastq.gz  $up1 \\
             ${prefix}_trimm_pair_R2.fastq.gz $up2 \\
-            > ${prefix}.trimm_pe.log
+            > ${prefix}.trimm.log
 
             cat <<-END_VERSIONS > versions.yml
             "${task.process}":
-              TRIMM_PE: \$(trimmomatic --version)
+              TRIMM: \$(trimmomatic --version)
             END_VERSIONS
             """
 
@@ -41,11 +41,11 @@ process TRIMM_PE {
             """
             touch ${prefix}_trimm_pair_R1.fastq.gz ${prefix}_trimm_pair_R2.fastq.gz
             touch ${prefix}_trimm_unpair_R1.fastq.gz ${prefix}_trimm_unpair_R2.fastq.gz
-            touch ${prefix}.trimm_pe.log
+            touch ${prefix}.trimm.log
 
             cat <<-END_VERSIONS > versions.yml
             "${task.process}":
-              TRIMM_PE: \$(trimmomatic --version)
+              TRIMM: \$(trimmomatic --version)
             END_VERSIONS
             """
 

--- a/modules/local/trimm_unmerge.nf
+++ b/modules/local/trimm_unmerge.nf
@@ -43,8 +43,11 @@ process TRIMM_UNMERGE {
             def prefix = task.ext.prefix ?: "${meta.id}"
 
             """
-            touch ${prefix}_trimm_pair_R1.fastq.gz ${prefix}_trimm_pair_R2.fastq.gz
-            touch ${prefix}_trimm_unpair_R1.fastq.gz ${prefix}_trimm_unpair_R2.fastq.gz
+            touch ${prefix}_unmapped_cat_unmerge_pair_R1.fastq.gz
+            touch ${prefix}_unmapped_cat_unmerge_unpair_R1.fastq.gz
+            touch ${prefix}_unmapped_cat_unmerge_pair_R2.fastq.gz
+            touch ${prefix}_unmapped_cat_unmerge_unpair_R2.fastq.gz
+
             touch ${prefix}.trimm_unmerge.log
 
             cat <<-END_VERSIONS > versions.yml

--- a/subworkflows/local/denovo.nf
+++ b/subworkflows/local/denovo.nf
@@ -4,7 +4,7 @@ include { TRIMM_MERGE       } from "../../modules/local/trimm_merge"
 /* include { SPADES_DENOVO     } from "../../modules/local/spades_denovo" */
 /* include { MMSEQ2_ELINCLUST  } from "../../modules/local/mmseq2_elinclust" */
 
-workflow DENOVO_PE_WF {
+workflow DENOVO_WF {
     take:
         ch_deduped_normalized_fastqgz
 

--- a/subworkflows/local/host_removal.nf
+++ b/subworkflows/local/host_removal.nf
@@ -17,6 +17,10 @@ workflow HOST_REMOVAL_WF {
 
         MINIMAP2_HOST_REMOVAL( MINIMAP2_INDEX.out.index, fastq_ch )
 
+
+}
+
+/*
         BBMAP_SINGLETONS( MINIMAP2_HOST_REMOVAL.out.unmapped_singleton )
 
         ch_cat_input = MINIMAP2_HOST_REMOVAL.out.unmapped_pair
@@ -32,9 +36,9 @@ workflow HOST_REMOVAL_WF {
         BBMAP_DUDUPED_NORMALIZATION( BBMAP_DEDUPED_REFORMAT.out.reformatted_fastq )
 
         //TODO
-        /* FASTQC_BEFORE_MERGE */
-        /* MULTIQC_BEFORE_MERGE */
+        //FASTQC_BEFORE_MERGE
+        //MULTIQC_BEFORE_MERGE
 
     emit:
         deduped_normalized_fastqgz = BBMAP_DUDUPED_NORMALIZATION.out.norm_fastqgz
-}
+        */

--- a/subworkflows/local/host_removal.nf
+++ b/subworkflows/local/host_removal.nf
@@ -1,13 +1,13 @@
 include { BBMAP_DEDUPE                          } from "../../modules/local/bbmap_dedupe"
 include { BBMAP_DEDUPED_REFORMAT                } from "../../modules/local/bbmap_deduped_reformat"
 include { BBMAP_DUDUPED_NORMALIZATION           } from "../../modules/local/bbmap_deduped_normalization"
-include { BBMAP_REFORMAT as BBMAP_SINGLETONS_PE } from "../../modules/local/bbmap_reformat"
-include { CAT_PE                                } from "../../modules/local/cat_pe"
+include { BBMAP_REFORMAT as BBMAP_SINGLETONS    } from "../../modules/local/bbmap_reformat"
+include { CAT                                   } from "../../modules/local/cat"
 include { MINIMAP2_INDEX                        } from "../../modules/nf-core/minimap2/index"
 include { MINIMAP2_HOST_REMOVAL                 } from "../../modules/local/minimap2_host_removal"
 
 
-workflow HOST_REMOVAL_PE_WF {
+workflow HOST_REMOVAL_WF {
     take:
         ref_fasta_ch
         fastq_ch
@@ -17,15 +17,15 @@ workflow HOST_REMOVAL_PE_WF {
 
         MINIMAP2_HOST_REMOVAL( MINIMAP2_INDEX.out.index, fastq_ch )
 
-        BBMAP_SINGLETONS_PE( MINIMAP2_HOST_REMOVAL.out.unmapped_singleton )
+        BBMAP_SINGLETONS( MINIMAP2_HOST_REMOVAL.out.unmapped_singleton )
 
-        ch_cat_pe_input = MINIMAP2_HOST_REMOVAL.out.unmapped_pair
-                                    .join(BBMAP_SINGLETONS_PE.out.singleton_pair)
-                                    .dump(tag: "HOST_REMOVAL_PE: ch_in_CAT_PE" )
+        ch_cat_input = MINIMAP2_HOST_REMOVAL.out.unmapped_pair
+                                    .join(BBMAP_SINGLETONS.out.singleton_pair)
+                                    .dump(tag: "HOST_REMOVAL: ch_cat_input" )
 
-        CAT_PE( ch_cat_pe_input )
+        CAT( ch_cat_input )
 
-        BBMAP_DEDUPE ( CAT_PE.out.fastqgz )
+        BBMAP_DEDUPE ( CAT.out.fastqgz )
 
         BBMAP_DEDUPED_REFORMAT( BBMAP_DEDUPE.out.deduped_fastqgz )
 

--- a/subworkflows/local/trimming_adapters.nf
+++ b/subworkflows/local/trimming_adapters.nf
@@ -4,9 +4,9 @@ include { BBMAP_PHIX                          } from '../../modules/local/bbmap_
 /* include { BBMAP_BBDUK as BBMAP_PHIX        } from '../../modules/nf-core/bbmap/bbduk' */
 include { TRIMM                               } from '../../modules/local/trimm'
 include { CAT_PAIR_UNPAIR                     } from '../../modules/local/cat_pair_unpair'
-include { FASTQC  as FASTQC_TRIMM_SE          } from '../../modules/nf-core/fastqc'
-include { FASTQC  as FASTQC_TRIMM_PE          } from '../../modules/nf-core/fastqc'
-include { MULTIQC as MULTIQC_TRIMM            } from '../../modules/nf-core/multiqc'
+/* include { FASTQC  as FASTQC_TRIMM_SE          } from '../../modules/nf-core/fastqc' */
+/* include { FASTQC  as FASTQC_TRIMM_PE          } from '../../modules/nf-core/fastqc' */
+/* include { MULTIQC as MULTIQC_TRIMM            } from '../../modules/nf-core/multiqc' */
 
 workflow TRIMMING_ADAPTERS_WF {
 
@@ -22,7 +22,7 @@ workflow TRIMMING_ADAPTERS_WF {
 
         TRIMM( BBMAP_PHIX.out.clean, params.adaptor ) 
 
-        //Filter single_end and paired_end samples
+        //Filter single_end and paired_end samples using branch operator
         ch_trimmed = TRIMM.out.paired
                                 .branch {
                                          se: it[0].single_end == true
@@ -36,9 +36,9 @@ workflow TRIMMING_ADAPTERS_WF {
         CAT_PAIR_UNPAIR( ch_trimm_all_pe )
 
 
+        //TODO 
         /* FASTQC_TRIMM( CAT_PAIR_UNPAIR.out.concatenated ) */
-
-        //MULTIQC_TRIMM( FASTQC_TRIMM.out.zip.collect{it[1]}, [], [], [] )
+        /* MULTIQC_TRIMM( FASTQC_TRIMM.out.zip.collect{it[1]}, [], [], [] ) */
 
     emit:
         /* fastqc_trimm_zip = FASTQC_TRIMM.out.zip.collect{it[1]} */

--- a/subworkflows/local/trimming_adapters.nf
+++ b/subworkflows/local/trimming_adapters.nf
@@ -1,6 +1,7 @@
 /* https://github.com/agudeloromero/EVEREST/blob/main/SMK/02_trimming_adaptors.smk */
 
 include { BBMAP_PHIX                       } from '../../modules/local/bbmap_phix'
+/* include { BBMAP_BBDUK as BBMAP_PHIX        } from '../../modules/nf-core/bbmap/bbduk' */
 include { TRIMM                            } from '../../modules/local/trimm'
 include { CAT_PAIR_UNPAIR                  } from '../../modules/local/cat_pair_unpair'
 include { FASTQC  as FASTQC_TRIMM          } from '../../modules/nf-core/fastqc'
@@ -12,9 +13,17 @@ workflow TRIMMING_ADAPTERS_WF {
         reads_ch // [ val(meta), [ reads ] ]
 
     main:
+
+        reads_ch.dump(tag:"reads_ch")
+
+        //TODO: Replace with the nf-core module
         BBMAP_PHIX( reads_ch ) 
 
         TRIMM( BBMAP_PHIX.out.clean, params.adaptor ) 
+
+}
+
+/*
 
         joint_trimm_ch = TRIMM.out.paired
                             .join(TRIMM.out.unpaired)
@@ -27,9 +36,10 @@ workflow TRIMMING_ADAPTERS_WF {
 
         FASTQC_TRIMM( CAT_PAIR_UNPAIR.out.concatenated )
 
-        /* MULTIQC_TRIMM( FASTQC_TRIMM.out.zip.collect{it[1]}, [], [], [] ) */
+        //MULTIQC_TRIMM( FASTQC_TRIMM.out.zip.collect{it[1]}, [], [], [] )
 
     emit:
         fastqc_trimm_zip = FASTQC_TRIMM.out.zip.collect{it[1]}
         cat_trimm_fastq  = CAT_PAIR_UNPAIR.out.concatenated
-}
+
+*/

--- a/subworkflows/local/trimming_adapters.nf
+++ b/subworkflows/local/trimming_adapters.nf
@@ -1,11 +1,12 @@
 /* https://github.com/agudeloromero/EVEREST/blob/main/SMK/02_trimming_adaptors.smk */
 
-include { BBMAP_PHIX                       } from '../../modules/local/bbmap_phix'
+include { BBMAP_PHIX                          } from '../../modules/local/bbmap_phix'
 /* include { BBMAP_BBDUK as BBMAP_PHIX        } from '../../modules/nf-core/bbmap/bbduk' */
-include { TRIMM                            } from '../../modules/local/trimm'
-include { CAT_PAIR_UNPAIR                  } from '../../modules/local/cat_pair_unpair'
-include { FASTQC  as FASTQC_TRIMM          } from '../../modules/nf-core/fastqc'
-include { MULTIQC as MULTIQC_TRIMM         } from '../../modules/nf-core/multiqc'
+include { TRIMM                               } from '../../modules/local/trimm'
+include { CAT_PAIR_UNPAIR                     } from '../../modules/local/cat_pair_unpair'
+include { FASTQC  as FASTQC_TRIMM_SE          } from '../../modules/nf-core/fastqc'
+include { FASTQC  as FASTQC_TRIMM_PE          } from '../../modules/nf-core/fastqc'
+include { MULTIQC as MULTIQC_TRIMM            } from '../../modules/nf-core/multiqc'
 
 workflow TRIMMING_ADAPTERS_WF {
 
@@ -14,32 +15,35 @@ workflow TRIMMING_ADAPTERS_WF {
 
     main:
 
-        reads_ch.dump(tag:"reads_ch")
+        /* reads_ch.dump(tag:"reads_ch") */
 
         //TODO: Replace with the nf-core module
         BBMAP_PHIX( reads_ch ) 
 
         TRIMM( BBMAP_PHIX.out.clean, params.adaptor ) 
 
-}
+        //Filter single_end and paired_end samples
+        ch_trimmed = TRIMM.out.paired
+                                .branch {
+                                         se: it[0].single_end == true
+                                         pe: it[0].single_end == false
+                                     }
 
-/*
-
-        joint_trimm_ch = TRIMM.out.paired
+        ch_trimm_all_pe = ch_trimmed.pe
                             .join(TRIMM.out.unpaired)
-                            .dump(tag: "TRIMM", pretty: true)
 
-        CAT_PAIR_UNPAIR( joint_trimm_ch )
 
-        CAT_PAIR_UNPAIR.out.concatenated
-                           .dump(tag: "CAT_PAIR_UNPAIR", pretty: true)
+        CAT_PAIR_UNPAIR( ch_trimm_all_pe )
 
-        FASTQC_TRIMM( CAT_PAIR_UNPAIR.out.concatenated )
+
+        /* FASTQC_TRIMM( CAT_PAIR_UNPAIR.out.concatenated ) */
 
         //MULTIQC_TRIMM( FASTQC_TRIMM.out.zip.collect{it[1]}, [], [], [] )
 
     emit:
-        fastqc_trimm_zip = FASTQC_TRIMM.out.zip.collect{it[1]}
-        cat_trimm_fastq  = CAT_PAIR_UNPAIR.out.concatenated
+        /* fastqc_trimm_zip = FASTQC_TRIMM.out.zip.collect{it[1]} */
+        cat_trimm_pe_fastq  = CAT_PAIR_UNPAIR.out.concatenated
+        cat_trimm_se_fastq  = ch_trimmed.se
 
-*/
+
+}

--- a/subworkflows/local/trimming_adapters.nf
+++ b/subworkflows/local/trimming_adapters.nf
@@ -1,12 +1,12 @@
-/* https://github.com/agudeloromero/EVEREST/blob/main/SMK/02_trimming_adaptors_PE.smk */
+/* https://github.com/agudeloromero/EVEREST/blob/main/SMK/02_trimming_adaptors.smk */
 
 include { BBMAP_PHIX                       } from '../../modules/local/bbmap_phix'
-include { TRIMM_PE                          } from '../../modules/local/trimm_pe'
+include { TRIMM                            } from '../../modules/local/trimm'
 include { CAT_PAIR_UNPAIR                  } from '../../modules/local/cat_pair_unpair'
 include { FASTQC  as FASTQC_TRIMM          } from '../../modules/nf-core/fastqc'
 include { MULTIQC as MULTIQC_TRIMM         } from '../../modules/nf-core/multiqc'
 
-workflow TRIMMING_ADAPTERS_PE_WF {
+workflow TRIMMING_ADAPTERS_WF {
 
     take:
         reads_ch // [ val(meta), [ reads ] ]
@@ -14,11 +14,11 @@ workflow TRIMMING_ADAPTERS_PE_WF {
     main:
         BBMAP_PHIX( reads_ch ) 
 
-        TRIMM_PE( BBMAP_PHIX.out.clean, params.adaptor ) 
+        TRIMM( BBMAP_PHIX.out.clean, params.adaptor ) 
 
-        joint_trimm_ch = TRIMM_PE.out.paired
-                            .join(TRIMM_PE.out.unpaired)
-                            .dump(tag: "TRIMM_PE", pretty: true)
+        joint_trimm_ch = TRIMM.out.paired
+                            .join(TRIMM.out.unpaired)
+                            .dump(tag: "TRIMM", pretty: true)
 
         CAT_PAIR_UNPAIR( joint_trimm_ch )
 

--- a/workflows/everest.nf
+++ b/workflows/everest.nf
@@ -96,9 +96,9 @@ workflow EVEREST {
 
     TRIMMING_ADAPTERS_WF( INPUT_CHECK.out.reads )
 
-    HOST_REMOVAL_WF( params.fasta, TRIMMING_ADAPTERS_WF.out.cat_trimm_fastq )
+    /* HOST_REMOVAL_WF( params.fasta, TRIMMING_ADAPTERS_WF.out.cat_trimm_fastq ) */
 
-    DENOVO_WF( HOST_REMOVAL_WF.out.deduped_normalized_fastqgz )
+    /* DENOVO_WF( HOST_REMOVAL_WF.out.deduped_normalized_fastqgz ) */
 
     //============================
     // FINISH: EVEREST WORKFLOW
@@ -124,8 +124,8 @@ workflow EVEREST {
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
 
-    //CUSTOM FILES
-    ch_multiqc_files = ch_multiqc_files.mix(TRIMMING_ADAPTERS_WF.out.fastqc_trimm_zip)
+    //FIXME: CUSTOM FILES
+    /* ch_multiqc_files = ch_multiqc_files.mix(TRIMMING_ADAPTERS_WF.out.fastqc_trimm_zip) */
 
     MULTIQC (
         ch_multiqc_files.collect(),

--- a/workflows/everest.nf
+++ b/workflows/everest.nf
@@ -38,9 +38,9 @@ ch_multiqc_custom_methods_description = params.multiqc_methods_description ? fil
 // SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
 //
 include { INPUT_CHECK             } from '../subworkflows/local/input_check'
-include { TRIMMING_ADAPTERS_PE_WF } from '../subworkflows/local/trimming_adapters_pe'
-include { HOST_REMOVAL_PE_WF      } from '../subworkflows/local/host_removal_pe'
-include { DENOVO_PE_WF            } from '../subworkflows/local/denovo_pe'
+include { TRIMMING_ADAPTERS_WF    } from '../subworkflows/local/trimming_adapters'
+include { HOST_REMOVAL_WF         } from '../subworkflows/local/host_removal'
+include { DENOVO_WF               } from '../subworkflows/local/denovo'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -94,11 +94,11 @@ workflow EVEREST {
     // PRE_TRIMMING_QC_WF -> Optional, reuse the module
 
 
-    TRIMMING_ADAPTERS_PE_WF( INPUT_CHECK.out.reads )
+    TRIMMING_ADAPTERS_WF( INPUT_CHECK.out.reads )
 
-    HOST_REMOVAL_PE_WF( params.fasta, TRIMMING_ADAPTERS_PE_WF.out.cat_trimm_fastq )
+    HOST_REMOVAL_WF( params.fasta, TRIMMING_ADAPTERS_WF.out.cat_trimm_fastq )
 
-    DENOVO_PE_WF( HOST_REMOVAL_PE_WF.out.deduped_normalized_fastqgz )
+    DENOVO_WF( HOST_REMOVAL_WF.out.deduped_normalized_fastqgz )
 
     //============================
     // FINISH: EVEREST WORKFLOW
@@ -125,7 +125,7 @@ workflow EVEREST {
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
 
     //CUSTOM FILES
-    ch_multiqc_files = ch_multiqc_files.mix(TRIMMING_ADAPTERS_PE_WF.out.fastqc_trimm_zip)
+    ch_multiqc_files = ch_multiqc_files.mix(TRIMMING_ADAPTERS_WF.out.fastqc_trimm_zip)
 
     MULTIQC (
         ch_multiqc_files.collect(),

--- a/workflows/everest.nf
+++ b/workflows/everest.nf
@@ -76,14 +76,6 @@ workflow EVEREST {
     )
     ch_versions = ch_versions.mix(INPUT_CHECK.out.versions)
 
-    //
-    // MODULE: Run FastQC
-    //
-    FASTQC (
-        INPUT_CHECK.out.reads
-    )
-    ch_versions = ch_versions.mix(FASTQC.out.versions.first())
-
 
     //============================
     // START: EVEREST WORKFLOW
@@ -96,13 +88,28 @@ workflow EVEREST {
 
     TRIMMING_ADAPTERS_WF( INPUT_CHECK.out.reads )
 
-    /* HOST_REMOVAL_WF( params.fasta, TRIMMING_ADAPTERS_WF.out.cat_trimm_fastq ) */
+    HOST_REMOVAL_WF( params.fasta, TRIMMING_ADAPTERS_WF.out.cat_trimm_pe_fastq )
 
-    /* DENOVO_WF( HOST_REMOVAL_WF.out.deduped_normalized_fastqgz ) */
+    //TODO:
+    //DENOVO_WF( HOST_REMOVAL_WF.out.deduped_normalized_fastqgz )
+    
+}
 
-    //============================
-    // FINISH: EVEREST WORKFLOW
-    //============================
+//============================
+// FINISH: EVEREST WORKFLOW
+//============================
+
+
+
+//FIXME Enable these once EVEREST is completed
+/*
+    //
+    // MODULE: Run FastQC
+    //
+    FASTQC (
+        INPUT_CHECK.out.reads
+    )
+    ch_versions = ch_versions.mix(FASTQC.out.versions.first())
 
 
     CUSTOM_DUMPSOFTWAREVERSIONS (
@@ -125,7 +132,7 @@ workflow EVEREST {
     ch_multiqc_files = ch_multiqc_files.mix(FASTQC.out.zip.collect{it[1]}.ifEmpty([]))
 
     //FIXME: CUSTOM FILES
-    /* ch_multiqc_files = ch_multiqc_files.mix(TRIMMING_ADAPTERS_WF.out.fastqc_trimm_zip) */
+    //ch_multiqc_files = ch_multiqc_files.mix(TRIMMING_ADAPTERS_WF.out.fastqc_trimm_zip)
 
     MULTIQC (
         ch_multiqc_files.collect(),
@@ -135,6 +142,7 @@ workflow EVEREST {
     )
     multiqc_report = MULTIQC.out.report.toList()
 }
+*/
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hi Patricia,

With this PR I have taken a step back and started to accommodate the PE/SE workflows from the `EVEREST_META` codebase. 


Here's the `samplesheet_stub.csv` 


|sample    |fastq_1                                                 |fastq_2                                                 |
|----------|--------------------------------------------------------|--------------------------------------------------------|
|SRX2533327|_resources/stub_dataset/SRX2533327_SRR5224148_1.fastq.gz|_resources/stub_dataset/SRX2533327_SRR5224148_2.fastq.gz|
|SRX2533328|_resources/stub_dataset/SRX2533328_SRR5224149_1.fastq.gz|_resources/stub_dataset/SRX2533328_SRR5224149_2.fastq.gz|
|SRX2533337|_resources/stub_dataset/SRX2533337_SRR5224158_1.fastq.gz|_resources/stub_dataset/SRX2533337_SRR5224158_2.fastq.gz|
|SRX2533330|_resources/stub_dataset/SRX2533330_1.fastq.gz           |                                                        |



And a sample run with the same workflow for both PE/SE

![image](https://user-images.githubusercontent.com/12799326/231087533-81f81123-8041-4f60-9b49-f2d1b25d0614.jpeg)
