### PR TITLE
Accommodate the SE/PE/RNASEQ samples in host removal worfklow

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -35,6 +35,11 @@
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
                         "installed_by": ["modules"]
                     },
+                    "kallisto/index": {
+                        "branch": "master",
+                        "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
+                        "installed_by": ["modules"]
+                    },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",

--- a/modules/local/CAT_pair_unpair.nf
+++ b/modules/local/CAT_pair_unpair.nf
@@ -2,7 +2,7 @@ process CAT_PAIR_UNPAIR {
         tag "$meta.id"
         label 'process_medium'
 
-    //		conda (params.enable_conda ? 'bioconda::trimmomatic=0.39' : null)
+        conda "envs/minimap2.yml"
 
         input:
         tuple val(meta), path(paired), path(unpaired)

--- a/modules/local/bbmap_deduped_normalization.nf
+++ b/modules/local/bbmap_deduped_normalization.nf
@@ -12,7 +12,7 @@ process BBMAP_DUDUPED_NORMALIZATION {
         tuple val(meta), path(reads)
 
         output:
-        tuple val(meta), path('*_unmapped_cat_dedup_norm_R*.fastq.gz')		, emit: norm_fastqgz
+        tuple val(meta), path('*_dedup_norm_R*.fastq.gz')		              , emit: norm_fastqgz
         tuple val(meta), path('*bbmap_duduped_normalization.log')		      , emit: log
         path "versions.yml"							                                  , emit: versions
 

--- a/modules/local/bbmap_deduped_reformat.nf
+++ b/modules/local/bbmap_deduped_reformat.nf
@@ -2,15 +2,15 @@ process BBMAP_DEDUPED_REFORMAT {
         tag "$meta.id"
         label 'process_medium'
 
-        conda (params.enable_conda ? 'bioconda::bbmap=38.96' : null)
+        conda "envs/BBMAP.yml"
 
-        container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-            'https://depot.galaxyproject.org/singularity/bbmap:38.96--h5c4e2a8_0':
-            'quay.io/biocontainers/bbmap:38.96--h5c4e2a8_0' }"
+        /* container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ? */
+        /*     'https://depot.galaxyproject.org/singularity/bbmap:38.96--h5c4e2a8_0': */
+        /*     'quay.io/biocontainers/bbmap:38.96--h5c4e2a8_0' }" */
 
 
         input:
-        tuple val(meta), path(deduped_fastqgz)
+        tuple val(meta), path(cat_deduped_fastqgz)
 
         output:
         tuple val(meta), path('*_unmapped_cat_dedup_R*.fastq.gz')		, emit: reformatted_fastq
@@ -18,13 +18,13 @@ process BBMAP_DEDUPED_REFORMAT {
         path "versions.yml"							                            , emit: versions
 
         script:
-        def args = task.ext.args ?: '-Xmx20000m'
+        def args = task.ext.args ?: "-Xmx${task.memory}m"
         def prefix = task.ext.prefix ?: "${meta.id}"
 
         """
         reformat.sh \\
           $args \\
-          in1=$deduped_fastqgz \\
+          in1=$cat_deduped_fastqgz \\
           out1=${prefix}_unmapped_cat_dedup_R1.fastq.gz out2=${prefix}_unmapped_cat_dedup_R2.fastq.gz \\
           out=${prefix}_noclean_R1.fastq.gz out2=${prefix}_noclean_R2.fastq.gz \\
           2> ${prefix}.bbmap_deduped_reformat.log

--- a/modules/nf-core/kallisto/index/main.nf
+++ b/modules/nf-core/kallisto/index/main.nf
@@ -1,0 +1,44 @@
+process KALLISTO_INDEX {
+    tag "$fasta"
+    label 'process_medium'
+
+    conda "bioconda::kallisto=0.46.2"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/kallisto:0.46.2--h4f7b962_1' :
+        'quay.io/biocontainers/kallisto:0.46.2--h4f7b962_1' }"
+
+    input:
+    path fasta
+
+    output:
+    path "kallisto" , emit: idx
+    path "versions.yml" , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    kallisto \\
+        index \\
+        $args \\
+        -i kallisto \\
+        $fasta
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kallisto: \$(echo \$(kallisto 2>&1) | sed 's/^kallisto //; s/Usage.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch kallisto
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kallisto: \$(echo \$(kallisto 2>&1) | sed 's/^kallisto //; s/Usage.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/kallisto/index/meta.yml
+++ b/modules/nf-core/kallisto/index/meta.yml
@@ -1,0 +1,31 @@
+name: kallisto_index
+description: Create kallisto index
+keywords:
+  - index
+tools:
+  - kallisto:
+      description: Quantifying abundances of transcripts from bulk and single-cell RNA-Seq data, or more generally of target sequences using high-throughput sequencing reads.
+      homepage: https://pachterlab.github.io/kallisto/
+      documentation: https://pachterlab.github.io/kallisto/manual
+      tool_dev_url: https://github.com/pachterlab/kallisto
+
+      licence: ["BSD-2-Clause"]
+
+input:
+  - fasta:
+      type: file
+      description: genome fasta file
+      pattern: "*.{fasta}"
+
+output:
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - idx:
+      type: index
+      description: Kallisto genome index
+      pattern: "*.idx"
+
+authors:
+  - "@ggabernet"

--- a/subworkflows/local/host_removal.nf
+++ b/subworkflows/local/host_removal.nf
@@ -3,6 +3,7 @@ include { BBMAP_DEDUPED_REFORMAT                } from "../../modules/local/bbma
 include { BBMAP_DUDUPED_NORMALIZATION           } from "../../modules/local/bbmap_deduped_normalization"
 include { BBMAP_REFORMAT as BBMAP_SINGLETONS    } from "../../modules/local/bbmap_reformat"
 include { CAT                                   } from "../../modules/local/cat"
+include { KALLISTO_INDEX                        } from '../../modules/nf-core/kallisto/index/main'                                            
 include { MINIMAP2_INDEX                        } from "../../modules/nf-core/minimap2/index"
 include { MINIMAP2_HOST_REMOVAL                 } from "../../modules/local/minimap2_host_removal"
 include { PIGZ                                  } from "../../modules/local/pigz"

--- a/subworkflows/local/host_removal.nf
+++ b/subworkflows/local/host_removal.nf
@@ -5,31 +5,42 @@ include { BBMAP_REFORMAT as BBMAP_SINGLETONS    } from "../../modules/local/bbma
 include { CAT                                   } from "../../modules/local/cat"
 include { MINIMAP2_INDEX                        } from "../../modules/nf-core/minimap2/index"
 include { MINIMAP2_HOST_REMOVAL                 } from "../../modules/local/minimap2_host_removal"
+include { PIGZ                                  } from "../../modules/local/pigz"
 
 
 workflow HOST_REMOVAL_WF {
     take:
         ref_fasta_ch
-        fastq_ch
+        all_fastq_ch
 
     main:
         MINIMAP2_INDEX( ref_fasta_ch  )
 
-        MINIMAP2_HOST_REMOVAL( MINIMAP2_INDEX.out.index, fastq_ch )
+        MINIMAP2_HOST_REMOVAL( MINIMAP2_INDEX.out.index, all_fastq_ch )
 
+        //NOTE: Process the PE-singletons here
+        BBMAP_SINGLETONS( MINIMAP2_HOST_REMOVAL.out.singleton )
 
-}
-
-/*
-        BBMAP_SINGLETONS( MINIMAP2_HOST_REMOVAL.out.unmapped_singleton )
-
-        ch_cat_input = MINIMAP2_HOST_REMOVAL.out.unmapped_pair
+        ch_cat_input = MINIMAP2_HOST_REMOVAL.out.unmapped
                                     .join(BBMAP_SINGLETONS.out.singleton_pair)
                                     .dump(tag: "HOST_REMOVAL: ch_cat_input" )
 
         CAT( ch_cat_input )
 
-        BBMAP_DEDUPE ( CAT.out.fastqgz )
+        //NOTE: Combine the SE and PE_Singletons FASTQ files here
+        ch_pigz_input = CAT.out.fastq
+                            .concat(MINIMAP2_HOST_REMOVAL.out.unmapped)
+                            .unique()
+                            .dump(tag: "ch_pigz_input")
+
+        PIGZ(ch_pigz_input)
+
+
+}
+
+/*
+
+        BBMAP_DEDUPE ( CAT.out.fastq )
 
         BBMAP_DEDUPED_REFORMAT( BBMAP_DEDUPE.out.deduped_fastqgz )
 

--- a/subworkflows/local/trimming_adapters.nf
+++ b/subworkflows/local/trimming_adapters.nf
@@ -44,7 +44,7 @@ workflow TRIMMING_ADAPTERS_WF {
 
        all_fastq_ch = ch_trimmed.se
                         .mix(CAT_PAIR_UNPAIR.out.concatenated)
-                        .dump(tag:"all_fastq_ch")
+                        /* .dump(tag:"all_fastq_ch") */
 
 
 

--- a/subworkflows/local/trimming_adapters.nf
+++ b/subworkflows/local/trimming_adapters.nf
@@ -40,10 +40,18 @@ workflow TRIMMING_ADAPTERS_WF {
         /* FASTQC_TRIMM( CAT_PAIR_UNPAIR.out.concatenated ) */
         /* MULTIQC_TRIMM( FASTQC_TRIMM.out.zip.collect{it[1]}, [], [], [] ) */
 
+
+
+       all_fastq_ch = ch_trimmed.se
+                        .mix(CAT_PAIR_UNPAIR.out.concatenated)
+                        .dump(tag:"all_fastq_ch")
+
+
+
     emit:
         /* fastqc_trimm_zip = FASTQC_TRIMM.out.zip.collect{it[1]} */
+        trimm_se_fastq  = ch_trimmed.se
         cat_trimm_pe_fastq  = CAT_PAIR_UNPAIR.out.concatenated
-        cat_trimm_se_fastq  = ch_trimmed.se
-
+        ch_all_fastq = all_fastq_ch
 
 }

--- a/workflows/everest.nf
+++ b/workflows/everest.nf
@@ -88,7 +88,7 @@ workflow EVEREST {
 
     TRIMMING_ADAPTERS_WF( INPUT_CHECK.out.reads )
 
-    HOST_REMOVAL_WF( params.fasta, TRIMMING_ADAPTERS_WF.out.cat_trimm_pe_fastq )
+    HOST_REMOVAL_WF( params.fasta, TRIMMING_ADAPTERS_WF.out.ch_all_fastq )
 
     //TODO:
     //DENOVO_WF( HOST_REMOVAL_WF.out.deduped_normalized_fastqgz )


### PR DESCRIPTION
Hi Patricia,

With this PR, I've accommodated the `SE` and `PE` driven choices for the HOST_REMOVAL_WF subworkflow.

My next goal is to accommodate the RNASEQ samples within this step as well.




Here's the `samplesheet_stub.csv` 


|sample    |fastq_1                                                 |fastq_2                                                 |
|----------|--------------------------------------------------------|--------------------------------------------------------|
|SRX2533327|_resources/stub_dataset/SRX2533327_SRR5224148_1.fastq.gz|_resources/stub_dataset/SRX2533327_SRR5224148_2.fastq.gz|
|SRX2533328|_resources/stub_dataset/SRX2533328_SRR5224149_1.fastq.gz|_resources/stub_dataset/SRX2533328_SRR5224149_2.fastq.gz|
|SRX2533337|_resources/stub_dataset/SRX2533337_SRR5224158_1.fastq.gz|_resources/stub_dataset/SRX2533337_SRR5224158_2.fastq.gz|
|SRX2533330|_resources/stub_dataset/SRX2533330_1.fastq.gz           |                                                        |


Here's the sample run 

```
$ nextflow run main.nf -profile test_stub -stub  -params-file _resources/stub_params.yml 

```

![image](https://user-images.githubusercontent.com/12799326/232402036-129d97a6-6ff9-4f72-a11f-6448f089f4a4.jpeg)

