### PR TITLE
Feature/vrhyme reneo

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -314,4 +314,18 @@ process {
         ]
     }
 
+
+
+    //MISC
+
+    withName: VRHYME_VRHYME {
+        publishDir = [
+            path: { "${params.outdir}/vrhyme" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
+
+
+
 }

--- a/modules.json
+++ b/modules.json
@@ -128,6 +128,11 @@
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
                         "installed_by": ["modules"]
+                    },
+                    "vrhyme/vrhyme": {
+                        "branch": "master",
+                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "installed_by": ["modules"]
                     }
                 }
             },

--- a/modules/nf-core/vrhyme/vrhyme/environment.yml
+++ b/modules/nf-core/vrhyme/vrhyme/environment.yml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+
+dependencies:
+  - bioconda::vrhyme=1.1.0
+  - conda-forge::numpy=1.23.5
+  - conda-forge::python=3.10.8
+  - conda-forge::scikit-learn=1.2.2

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -1,0 +1,76 @@
+process VRHYME_VRHYME {
+    tag "$meta.id"
+    label 'process_high'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/vrhyme:1.1.0--pyhdfd78af_1':
+        'biocontainers/vrhyme:1.1.0--pyhdfd78af_1' }"
+
+    input:
+    tuple val(meta), path(reads)
+    tuple val(meta2), path(fasta)
+
+    output:
+    tuple val(meta), path("vRhyme_best_bins_fasta/")                , emit: bins
+    tuple val(meta), path("**/vRhyme_best_bins.*.membership.tsv")   , emit: membership
+    tuple val(meta), path("**/vRhyme_best_bins.*.summary.tsv")      , emit: summary
+    path "versions.yml"                                             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def fasta_input = fasta.toString().replaceAll(/\.gz$/, '')
+    def gunzip      = fasta.getExtension() == "gz" ? "gunzip -c ${fasta} > ${fasta_input}" : ""
+    def cleanup     = fasta.getExtension() == "gz" ? "rm ${fasta_input}" : ""
+    """
+    ${gunzip}
+
+    vRhyme \\
+        -i $fasta_input \\
+        -r $reads \\
+        -o $prefix \\
+        -t $task.cpus \\
+        $args
+
+    mv $prefix/vRhyme_best_bins_fasta/ vRhyme_best_bins_fasta
+
+    ${cleanup}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        vrhyme: \$(echo \$(vRhyme --version 2>&1) | sed 's/^.*vRhyme v//; s/Using.*\$//' ))
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir -p $prefix
+    touch $prefix/vRhyme_best_bins.19.membership.tsv
+    touch $prefix/vRhyme_best_bins.19.summary.tsv
+    mkdir -p vRhyme_best_bins_fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_1.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_10.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_11.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_12.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_13.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_14.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_2.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_3.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_4.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_5.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_6.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_7.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_8.fasta
+    touch vRhyme_best_bins_fasta/vRhyme_bin_9.fasta
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        vrhyme: \$(echo \$(vRhyme --version 2>&1) | sed 's/^.*vRhyme v//; s/Using.*\$//' ))
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -11,7 +11,7 @@ process VRHYME_VRHYME {
     tuple val(meta), path(fasta), path(reads)
 
     output:
-    tuple val(meta), path("**/vRhyme_best_bins_fasta/")        , emit: bins
+    tuple val(meta), path("$prefix/vRhyme_best_bins_fasta/")        , emit: bins
     tuple val(meta), path("**/vRhyme_best_bins.*.membership.tsv")   , emit: membership
     tuple val(meta), path("**/vRhyme_best_bins.*.summary.tsv")      , emit: summary
     path "versions.yml"                                             , emit: versions
@@ -35,7 +35,7 @@ process VRHYME_VRHYME {
         -t $task.cpus \\
         $args
 
-    mv $prefix/vRhyme_best_bins_fasta/ vRhyme_best_bins_fasta
+    #mv $prefix/vRhyme_best_bins_fasta/ vRhyme_best_bins_fasta
 
     ${cleanup}
 

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -11,7 +11,7 @@ process VRHYME_VRHYME {
     tuple val(meta), path(fasta), path(reads)
 
     output:
-    tuple val(meta), path("vRhyme_best_bins_fasta/")                , emit: bins
+    tuple val(meta), path("$prefix/vRhyme_best_bins_fasta/")        , emit: bins
     tuple val(meta), path("**/vRhyme_best_bins.*.membership.tsv")   , emit: membership
     tuple val(meta), path("**/vRhyme_best_bins.*.summary.tsv")      , emit: summary
     path "versions.yml"                                             , emit: versions

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -11,7 +11,7 @@ process VRHYME_VRHYME {
     tuple val(meta), path(fasta), path(reads)
 
     output:
-    tuple val(meta), path("$prefix/vRhyme_best_bins_fasta/")        , emit: bins
+    tuple val(meta), path("**/vRhyme_best_bins_fasta/")        , emit: bins
     tuple val(meta), path("**/vRhyme_best_bins.*.membership.tsv")   , emit: membership
     tuple val(meta), path("**/vRhyme_best_bins.*.summary.tsv")      , emit: summary
     path "versions.yml"                                             , emit: versions

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -8,8 +8,7 @@ process VRHYME_VRHYME {
         'biocontainers/vrhyme:1.1.0--pyhdfd78af_1' }"
 
     input:
-    tuple val(meta), path(reads)
-    tuple val(meta2), path(fasta)
+    tuple val(meta), path(fasta)
 
     output:
     tuple val(meta), path("vRhyme_best_bins_fasta/")                , emit: bins
@@ -31,7 +30,6 @@ process VRHYME_VRHYME {
 
     vRhyme \\
         -i $fasta_input \\
-        -r $reads \\
         -o $prefix \\
         -t $task.cpus \\
         $args

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -8,7 +8,8 @@ process VRHYME_VRHYME {
         'biocontainers/vrhyme:1.1.0--pyhdfd78af_1' }"
 
     input:
-    tuple val(meta), path(fasta)
+    tuple val(meta), path(reads)
+    tuple val(meta2), path(fasta)
 
     output:
     tuple val(meta), path("vRhyme_best_bins_fasta/")                , emit: bins
@@ -30,6 +31,7 @@ process VRHYME_VRHYME {
 
     vRhyme \\
         -i $fasta_input \\
+        -r $reads \\
         -o $prefix \\
         -t $task.cpus \\
         $args

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -8,8 +8,7 @@ process VRHYME_VRHYME {
         'biocontainers/vrhyme:1.1.0--pyhdfd78af_1' }"
 
     input:
-    tuple val(meta), path(reads)
-    tuple val(meta2), path(fasta)
+    tuple val(meta), path(fasta), path(reads)
 
     output:
     tuple val(meta), path("vRhyme_best_bins_fasta/")                , emit: bins

--- a/modules/nf-core/vrhyme/vrhyme/main.nf
+++ b/modules/nf-core/vrhyme/vrhyme/main.nf
@@ -11,7 +11,7 @@ process VRHYME_VRHYME {
     tuple val(meta), path(fasta), path(reads)
 
     output:
-    tuple val(meta), path("$prefix/vRhyme_best_bins_fasta/")        , emit: bins
+    tuple val(meta), path("**/vRhyme_best_bins_fasta/*.{fasta,ffn,faa}")        , emit: bins
     tuple val(meta), path("**/vRhyme_best_bins.*.membership.tsv")   , emit: membership
     tuple val(meta), path("**/vRhyme_best_bins.*.summary.tsv")      , emit: summary
     path "versions.yml"                                             , emit: versions

--- a/modules/nf-core/vrhyme/vrhyme/meta.yml
+++ b/modules/nf-core/vrhyme/vrhyme/meta.yml
@@ -1,0 +1,88 @@
+name: "vrhyme_vrhyme"
+description: Binning virus genomes from metagenomes
+keywords:
+  - binning
+  - bin
+  - phage
+  - virus
+  - vrhyme
+tools:
+  - "vrhyme":
+      description: "vRhyme functions by utilizing coverage variance comparisons and
+        supervised machine learning classification of sequence features to construct
+        viral metagenome-assembled genomes (vMAGs)."
+      homepage: https://github.com/AnantharamanLab/vRhyme
+      documentation: https://github.com/AnantharamanLab/vRhyme
+      tool_dev_url: https://github.com/AnantharamanLab/vRhyme
+      doi: 10.1093/nar/gkac341
+      licence: ["GPL v3", "GPL v3 license"]
+      identifier: biotools:vrhyme
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test']
+    - reads:
+        type: file
+        description: Preprocessed FASTQ file containing sample reads
+        pattern: "*.{fastq}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing fasta information
+          e.g. [ id:'test']
+    - fasta:
+        type: file
+        description: Contigs/scaffolds identified as viral
+        pattern: "*.{fna,fasta,fa,fasta.gz,fa.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+output:
+  bins:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - vRhyme_best_bins_fasta/:
+          type: directory
+          description: Directory containing bin FASTA files
+          pattern: "**/vRhyme_best_bins_fasta/"
+  membership:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "**/vRhyme_best_bins.*.membership.tsv":
+          type: file
+          description: TSV file describing the contig/scaffold membership of each bin
+          pattern: "vRhyme_best_bins.*.membership.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  summary:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test' ]
+      - "**/vRhyme_best_bins.*.summary.tsv":
+          type: file
+          description: TSV file summarizing the attributes of each bin
+          pattern: "vRhyme_best_bins.*.summary.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
+authors:
+  - "@CarsonJM"
+maintainers:
+  - "@CarsonJM"

--- a/modules/nf-core/vrhyme/vrhyme/tests/main.nf.test
+++ b/modules/nf-core/vrhyme/vrhyme/tests/main.nf.test
@@ -1,0 +1,76 @@
+
+nextflow_process {
+
+    name "Test Process VRHYME_VRHYME"
+    script "../main.nf"
+    process "VRHYME_VRHYME"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "modules_vrhyme"
+    tag "vrhyme"
+    tag "vrhyme/vrhyme"
+
+    test("test-vrhyme-vrhyme") {
+
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test', single_end:false ],
+				    [
+				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test1_1.fastq.gz', checkIfExists: true),
+				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test1_2.fastq.gz', checkIfExists: true)
+				    ]
+				]
+				input[1] = [
+				    [ id:'test', single_end:false ],
+				    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fasta/test1.contigs.fa.gz', checkIfExists: true)
+				]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    file(process.out.bins[0][1]).listFiles().collect { it.name }.toSorted(), // Some files are unstable
+                    process.out.membership,
+                    file(process.out.summary[0][1]).name, // unstable
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("test-vrhyme-vrhyme-stub") {
+        options '-stub'
+        when {
+            process {
+                """
+                input[0] = [
+				    [ id:'test', single_end:false ],
+				    [
+				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test1_1.fastq.gz', checkIfExists: true),
+				        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fastq/test1_2.fastq.gz', checkIfExists: true)
+				    ]
+				]
+				input[1] = [
+				    [ id:'test', single_end:false ],
+				    file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/illumina/fasta/test1.contigs.fa.gz', checkIfExists: true)
+				]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/vrhyme/vrhyme/tests/main.nf.test.snap
+++ b/modules/nf-core/vrhyme/vrhyme/tests/main.nf.test.snap
@@ -1,0 +1,169 @@
+{
+    "test-vrhyme-vrhyme": {
+        "content": [
+            [
+                "vRhyme_bin_1.faa",
+                "vRhyme_bin_1.fasta",
+                "vRhyme_bin_1.ffn",
+                "vRhyme_bin_10.faa",
+                "vRhyme_bin_10.fasta",
+                "vRhyme_bin_10.ffn",
+                "vRhyme_bin_11.faa",
+                "vRhyme_bin_11.fasta",
+                "vRhyme_bin_11.ffn",
+                "vRhyme_bin_12.faa",
+                "vRhyme_bin_12.fasta",
+                "vRhyme_bin_12.ffn",
+                "vRhyme_bin_13.faa",
+                "vRhyme_bin_13.fasta",
+                "vRhyme_bin_13.ffn",
+                "vRhyme_bin_14.faa",
+                "vRhyme_bin_14.fasta",
+                "vRhyme_bin_14.ffn",
+                "vRhyme_bin_2.faa",
+                "vRhyme_bin_2.fasta",
+                "vRhyme_bin_2.ffn",
+                "vRhyme_bin_3.faa",
+                "vRhyme_bin_3.fasta",
+                "vRhyme_bin_3.ffn",
+                "vRhyme_bin_4.faa",
+                "vRhyme_bin_4.fasta",
+                "vRhyme_bin_4.ffn",
+                "vRhyme_bin_5.faa",
+                "vRhyme_bin_5.fasta",
+                "vRhyme_bin_5.ffn",
+                "vRhyme_bin_6.faa",
+                "vRhyme_bin_6.fasta",
+                "vRhyme_bin_6.ffn",
+                "vRhyme_bin_7.faa",
+                "vRhyme_bin_7.fasta",
+                "vRhyme_bin_7.ffn",
+                "vRhyme_bin_8.faa",
+                "vRhyme_bin_8.fasta",
+                "vRhyme_bin_8.ffn",
+                "vRhyme_bin_9.faa",
+                "vRhyme_bin_9.fasta",
+                "vRhyme_bin_9.ffn"
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "vRhyme_best_bins.19.membership.tsv:md5,a24fe8417dd21c2db3da84cf51cff750"
+                ]
+            ],
+            "vRhyme_best_bins.19.summary.tsv",
+            [
+                "versions.yml:md5,3806574bd72718ff75e849d015ed0097"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-03T21:20:45.925942"
+    },
+    "test-vrhyme-vrhyme-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "vRhyme_bin_1.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_10.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_11.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_12.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_13.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_14.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_2.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_3.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_4.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_5.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_6.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_7.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_8.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_9.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "vRhyme_best_bins.19.membership.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "vRhyme_best_bins.19.summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    "versions.yml:md5,3806574bd72718ff75e849d015ed0097"
+                ],
+                "bins": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "vRhyme_bin_1.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_10.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_11.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_12.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_13.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_14.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_2.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_3.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_4.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_5.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_6.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_7.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_8.fasta:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "vRhyme_bin_9.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ]
+                    ]
+                ],
+                "membership": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "vRhyme_best_bins.19.membership.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "vRhyme_best_bins.19.summary.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,3806574bd72718ff75e849d015ed0097"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-09-02T16:38:33.310046"
+    }
+}

--- a/subworkflows/local/denovo.nf
+++ b/subworkflows/local/denovo.nf
@@ -63,17 +63,17 @@ workflow DENOVO_WF {
 
     */
 
-        ch_reneo_input = SPADES_DENOVO.out.scaffolds_graph
-                            .join(TRIMM_UNMERGE.out.paired)
-                            .dump(tag: "ch_reneo_input")
 
+        // ch_reneo_input = SPADES_DENOVO.out.scaffolds_graph
+        //                     .join(TRIMM_UNMERGE.out.paired)
+        //                     .dump(tag: "ch_reneo_input")
 
 
         //TODO: Confirm if the issue still persists
         // RENEO( ch_reneo_input )
 
         ch_vrhyme_input = SPADES_DENOVO.out.scaffolds
-                            .join(ch_trimm_combined)
+                            .join(TRIMM_MERGE.out.paired)
                             .dump(tag: "ch_vrhyme_input")
 
         VRHYME_VRHYME( SPADES_DENOVO.out.scaffolds )

--- a/subworkflows/local/denovo.nf
+++ b/subworkflows/local/denovo.nf
@@ -73,7 +73,7 @@ workflow DENOVO_WF {
         // RENEO( ch_reneo_input )
 
         ch_vrhyme_input = SPADES_DENOVO.out.scaffolds
-                            .join(TRIMM_MERGE.out.paired)
+                            .join(TRIMM_UNMERGE.out.paired)
                             .dump(tag: "ch_vrhyme_input")
 
         VRHYME_VRHYME( SPADES_DENOVO.out.scaffolds )

--- a/subworkflows/local/denovo.nf
+++ b/subworkflows/local/denovo.nf
@@ -79,7 +79,7 @@ workflow DENOVO_WF {
                             .join(TRIMM_UNMERGE.out.paired)
                             .dump(tag: "ch_vrhyme_input")
 
-        VRHYME_VRHYME( SPADES_DENOVO.out.scaffolds )
+        VRHYME_VRHYME( ch_vrhyme_input )
 
         MMSEQ2_ELINCLUST( SPADES_DENOVO.out.scaffolds )
 

--- a/subworkflows/local/denovo.nf
+++ b/subworkflows/local/denovo.nf
@@ -72,6 +72,9 @@ workflow DENOVO_WF {
         //TODO: Confirm if the issue still persists
         // RENEO( ch_reneo_input )
 
+
+        ch_spades_input.dump(tag: 'ch_spades_input')
+
         ch_vrhyme_input = SPADES_DENOVO.out.scaffolds
                             .join(TRIMM_UNMERGE.out.paired)
                             .dump(tag: "ch_vrhyme_input")

--- a/subworkflows/local/denovo.nf
+++ b/subworkflows/local/denovo.nf
@@ -72,6 +72,10 @@ workflow DENOVO_WF {
         //TODO: Confirm if the issue still persists
         // RENEO( ch_reneo_input )
 
+        ch_vrhyme_input = SPADES_DENOVO.out.scaffolds
+                            .join(ch_trimm_combined)
+                            .dump(tag: "ch_vrhyme_input")
+
         VRHYME_VRHYME( SPADES_DENOVO.out.scaffolds )
 
         MMSEQ2_ELINCLUST( SPADES_DENOVO.out.scaffolds )

--- a/subworkflows/local/denovo.nf
+++ b/subworkflows/local/denovo.nf
@@ -5,6 +5,7 @@ include { SPADES_DENOVO     } from "../../modules/local/spades_denovo"
 include { MMSEQ2_ELINCLUST  } from "../../modules/local/mmseq2_elinclust"
 include { PHAROKKA          } from "../../modules/local/pharokka.nf"
 include { RENEO             } from "../../modules/local/reneo.nf"
+include { VRHYME_VRHYME     } from "../../modules/nf-core/vrhyme/vrhyme/main"
 
 workflow DENOVO_WF {
     take:
@@ -60,7 +61,7 @@ workflow DENOVO_WF {
 
         TRIMM_UNMERGE.out.paired.dump(tag: "trimm_unmerge_out")
 
-*/
+    */
 
         ch_reneo_input = SPADES_DENOVO.out.scaffolds_graph
                             .join(TRIMM_UNMERGE.out.paired)
@@ -68,10 +69,10 @@ workflow DENOVO_WF {
 
 
 
-    //TODO: Confirm if the issue still persists
+        //TODO: Confirm if the issue still persists
         // RENEO( ch_reneo_input )
 
-        // VRHYME
+        VRHYME_VRHYME( SPADES_DENOVO.out.scaffolds )
 
         MMSEQ2_ELINCLUST( SPADES_DENOVO.out.scaffolds )
 


### PR DESCRIPTION
This pull request adds support for the vRhyme tool, which is used for binning virus genomes from metagenomes, to the pipeline. It introduces a new Nextflow module for vRhyme, integrates it into the denovo subworkflow, and provides the necessary configuration, environment definition, metadata, and tests to ensure correct operation.

**vRhyme module addition and integration:**

* Added a new Nextflow module for vRhyme (`VRHYME_VRHYME`) with its process definition in `main.nf`, specifying inputs, outputs, environment, and container requirements.
* Integrated the `VRHYME_VRHYME` process into the `DENOVO_WF` workflow in `subworkflows/local/denovo.nf`, including the channel joining logic for inputs. [[1]](diffhunk://#diff-55e7eb4cbcdc69200282fc75ed7ab7cba588b74fc523bb7557d8541df40b492fR8) [[2]](diffhunk://#diff-55e7eb4cbcdc69200282fc75ed7ab7cba588b74fc523bb7557d8541df40b492fL65-R82)
* Updated the modules configuration (`conf/modules.config`) and module registry (`modules.json`) to include the new vRhyme module. [[1]](diffhunk://#diff-bf809c928cb10b54d251dec8a140a2d5505150f97175d8d7b51dda9cc57971feR317-R330) [[2]](diffhunk://#diff-97c7fe3fe8f628d2435d00b93af4cb47052e8e1f3d33b7334d1a031fd15415d7R131-R135)

**Supporting files and documentation:**

* Added an environment definition (`environment.yml`) for the vRhyme module specifying required conda packages.
* Created a metadata file (`meta.yml`) describing the vRhyme module, its inputs, outputs, tools, and authorship.

**Testing:**

* Added comprehensive tests and test snapshots for the vRhyme module to ensure correct outputs and integration. [[1]](diffhunk://#diff-547343d68e6df7cdf0835534a7efc933f31750e3b9cd217554e719901e9ab53dR1-R76) [[2]](diffhunk://#diff-5d1fc135f801738c0cc9626b7dbb6edef2ce084a983fc959f5770fb6369cd847R1-R169)